### PR TITLE
Update webhook if events don't match

### DIFF
--- a/bin/out
+++ b/bin/out
@@ -60,6 +60,8 @@ async function processWebhook(source, params) {
         case 'create':
             if (existingHook == null) {
                 createWebhook(webhookEndpoint, 'POST', source.github_token, body);
+            } else if (existingHook.events !== body.events) {
+                updateWebhook(`${webhookEndpoint}/${existingHook.id}`, 'PATCH', source.github_token, body)
             } else {
                 log('Webhook already exists');
                 emit(existingHook);
@@ -87,6 +89,20 @@ function createWebhook(webhookEndpoint, method, githubToken, body) {
     callGithub(webhookEndpoint, method, githubToken, bodyString)
         .then(res => {
             log(`Successfully created webhook: ${res.body}`);
+            emit(JSON.parse(res.body));
+        })
+        .catch(error => {
+            log(error.stack);
+            process.exit(1);
+        });
+}
+
+function updateWebhook(webhookEndpoint, method, githubToken, body) {
+    const bodyString = JSON.stringify(body);
+
+    callGithub(webhookEndpoint, method, githubToken, bodyString)
+        .then(res => {
+            log(`Successfully updated webhook: ${res.body}`);
             emit(JSON.parse(res.body));
         })
         .catch(error => {


### PR DESCRIPTION
<!--
    Make sure your pull request is ready:
    - Read the contributing guidelines: https://github.com/homedepot/github-webhook-resource/blob/master/CONTRIBUTING.md
    - Include tests for this change
    - Update documentation to reflect this change (if appropriate)
-->

**What is the purpose of this pull request?**
<!-- Remove the empty space and paste an "X" inside the [] next to the correct item. -->
- [x] Bug fix
- [ ] Documentation update
- [ ] Code cleanup
- [ ] New feature
- [ ] Other (please explain):

**What changes did you make? (Give a brief overview)**
Webhook creation now checks if events types are different. 
If the configured events are different than what's already on GitHub, the existing webhook will be updated with the new events.
