### PR TITLE
Remove incorrect code coverage badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 Github Webhook Resource
 ===================================
 
-[![Build Status](https://travis-ci.org/homedepot/github-webhook-resource.svg?branch=master)](https://travis-ci.org/homedepot/github-webhook-resource) [![Coverage Status](https://coveralls.io/repos/github/homedepot/github-webhook-resource/badge.svg?branch=master)](https://coveralls.io/github/homedepot/github-webhook-resource?branch=master) [![Docker Pulls](https://img.shields.io/docker/pulls/homedepottech/github-webhook-resource.svg)](https://hub.docker.com/r/homedepottech/github-webhook-resource)
+[![Build Status](https://travis-ci.org/homedepot/github-webhook-resource.svg?branch=master)](https://travis-ci.org/homedepot/github-webhook-resource) [![Docker Pulls](https://img.shields.io/docker/pulls/homedepottech/github-webhook-resource.svg)](https://hub.docker.com/r/homedepottech/github-webhook-resource)
 
 By default, Concourse will `check` your resources once per minute to see if they have updated. In order to reduce excessive `checks`, you must configure webhooks to trigger Concourse externally. This resource automatically configures your GitHub respoitories to send webhooks to your Concourse pipeline the instant a change happens.
 


### PR DESCRIPTION
<!--
    Make sure your pull request is ready:
    - Read the contributing guidelines: https://github.com/homedepot/github-webhook-resource/blob/master/CONTRIBUTING.md
    - Include tests for this change
    - Update documentation to reflect this change (if appropriate)
-->

**What is the purpose of this pull request?**
<!-- Remove the empty space and paste an "X" inside the [] next to the correct item. -->
- [ ] Bug fix
- [X] Documentation update
- [ ] Code cleanup
- [ ] New feature
- [ ] Other (please explain):

**What changes did you make? (Give a brief overview)**
Coveralls badge does not reflect correct code coverage
