### PR TITLE
Enforce default events asap

### DIFF
--- a/bin/out
+++ b/bin/out
@@ -31,6 +31,10 @@ stdin.on('end', function () {
     const source = resourceConfig.source || {};
     const params = resourceConfig.params || {};
 
+    if (params.events === undefined) {
+        params.events = ['push']
+    }
+
     // Remove duplicates
     params.events = [...new Set(params.events)];
 

--- a/bin/out
+++ b/bin/out
@@ -31,7 +31,7 @@ stdin.on('end', function () {
     const source = resourceConfig.source || {};
     const params = resourceConfig.params || {};
 
-    if (params.events === undefined) {
+    if (params.events === undefined || params.events.length === 0) {
         params.events = ['push']
     }
 


### PR DESCRIPTION
<!--
    Make sure your pull request is ready:
    - Read the contributing guidelines: https://github.com/homedepot/github-webhook-resource/blob/master/CONTRIBUTING.md
    - Include tests for this change
    - Update documentation to reflect this change (if appropriate)
-->

**What is the purpose of this pull request?**
<!-- Remove the empty space and paste an "X" inside the [] next to the correct item. -->
- [X] Bug fix
- [ ] Documentation update
- [ ] Code cleanup
- [ ] New feature
- [ ] Other (please explain):

**What changes did you make? (Give a brief overview)**
Set default events when configuration is parsed, so that later comparisons (such as updates) will not compare against empty or undefined events.