### PR TITLE
Support pipeline name as param

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,10 @@ Create or delete a webhook using the configured parameters.
     webhook_token: your-token
     operation: create
     events: [push, pull_request]
+    pipeline: pipeline-name
+    pipeline_instance_vars: {
+        your_instance_var_name: value
+    }
 ```
 
 -	`org`: *Required.* Your github organization.
@@ -60,6 +64,8 @@ Create or delete a webhook using the configured parameters.
     -   `create` to create a new webhook. Updates existing webhook if your configuration differs from remote.
     -   `delete` to delete an existing webhook. Outputs current timestamp on non-existing webhooks.
 -   `events`: *Optional*. An array of [events](https://developer.github.com/webhooks/#events) which will trigger your webhook. Default: `push`
+-	`pipeline`: *Optional.* Defaults to the name of the pipeline executing the task
+-	`pipeline_instance_vars`: *Optional.* Instance vars to append to the webhook url. These help Concourse identify which [instance pipeline](https://concourse-ci.org/resources.html#schema.resource.webhook_token) it should invoke
 
 ## Example
 Include the github-webhook-resource in your pipeline.yml file

--- a/bin/out.js
+++ b/bin/out.js
@@ -46,16 +46,25 @@ stdin.on('end', function () {
 });
 
 function buildUrl(source, params) {
-    const instanceVars = buildInstanceVariables();
+    const instanceVars = buildInstanceVariables(params);
     return encodeURI(`${env.ATC_EXTERNAL_URL}/api/v1/teams/${env.BUILD_TEAM_NAME}/pipelines/${params.pipeline ? params.pipeline : env.BUILD_PIPELINE_NAME}/resources/${params.resource_name}/check/webhook?webhook_token=${params.webhook_token}${instanceVars}`);
 }
 
-function buildInstanceVariables() {
+function buildInstanceVariables(params) {
     let vars = "";
     if (env.BUILD_PIPELINE_INSTANCE_VARS) {
         try {
             const instanceVars = JSON.parse(env.BUILD_PIPELINE_INSTANCE_VARS)
             for (const [key, value] of Object.entries(instanceVars)) {
+                vars += `&vars.${key}="${value}"`;
+            }
+        } catch(exception) {
+            throw new Error(exception);
+        }
+    }
+    if ("pipeline_instance_vars" in params && params.pipeline_instance_vars) {
+        try {
+            for (const [key, value] of Object.entries(params.pipeline_instance_vars)) {
                 vars += `&vars.${key}="${value}"`;
             }
         } catch(exception) {

--- a/bin/out.js
+++ b/bin/out.js
@@ -47,7 +47,7 @@ stdin.on('end', function () {
 
 function buildUrl(source, params) {
     const instanceVars = buildInstanceVariables();
-    return encodeURI(`${env.ATC_EXTERNAL_URL}/api/v1/teams/${env.BUILD_TEAM_NAME}/pipelines/${env.BUILD_PIPELINE_NAME}/resources/${params.resource_name}/check/webhook?webhook_token=${params.webhook_token}${instanceVars}`);
+    return encodeURI(`${env.ATC_EXTERNAL_URL}/api/v1/teams/${env.BUILD_TEAM_NAME}/pipelines/${params.pipeline ? params.pipeline : env.BUILD_PIPELINE_NAME}/resources/${params.resource_name}/check/webhook?webhook_token=${params.webhook_token}${instanceVars}`);
 }
 
 function buildInstanceVariables() {
@@ -200,4 +200,4 @@ function log(message) {
     console.error(message);
 }
 
-module.exports = { buildInstanceVariables };
+module.exports = { buildInstanceVariables, buildUrl };

--- a/bin/out.test.js
+++ b/bin/out.test.js
@@ -16,25 +16,29 @@ describe('out', () => {
     describe('buildInstanceVaribles', () => {
         it('with unset variables, returns empty string', () => {
             delete process.env.BUILD_PIPELINE_INSTANCE_VARS;
-            const instanceVar = out.buildInstanceVariables();
+            const params = {};
+            const instanceVar = out.buildInstanceVariables(params);
             expect(instanceVar).toEqual('')
         });
     
         it('with empty variables, returns empty string', () => {
             process.env.BUILD_PIPELINE_INSTANCE_VARS = "{}";
-            const instanceVar = out.buildInstanceVariables();
+            const params = {pipeline_instance_vars: {}};
+            const instanceVar = out.buildInstanceVariables(params);
             expect(instanceVar).toEqual('')
         });
     
         it('with bad json, it throws an exception', () => {
             process.env.BUILD_PIPELINE_INSTANCE_VARS = "{695988";
-            expect(() => out.buildInstanceVariables()).toThrow();
+            const params = {};
+            expect(() => out.buildInstanceVariables(params)).toThrow();
         });
     
         it('with valid instance variables, it builds variable string to append to url', () => {
             process.env.BUILD_PIPELINE_INSTANCE_VARS = '{"name":"John", "age":30, "car":"Toyota"}';
-            const instanceVar = out.buildInstanceVariables();
-            expect(instanceVar).toEqual(`&vars.name="John"&vars.age="30"&vars.car="Toyota"`)
+            const params = {pipeline_instance_vars: {"license": "full"}};
+            const instanceVar = out.buildInstanceVariables(params);
+            expect(instanceVar).toEqual(`&vars.name="John"&vars.age="30"&vars.car="Toyota"&vars.license="full"`)
         });
     });
 

--- a/bin/out.test.js
+++ b/bin/out.test.js
@@ -1,6 +1,6 @@
 const out = require('./out');
 
-describe('buildInstanceVaribles', () => {
+describe('out', () => {
 
     const OLD_ENV = process.env;
 
@@ -13,26 +13,55 @@ describe('buildInstanceVaribles', () => {
         process.env = OLD_ENV;
     });
 
-    it('with unset variables, returns empty string', () => {
-        delete process.env.BUILD_PIPELINE_INSTANCE_VARS;
-        const instanceVar = out.buildInstanceVariables();
-        expect(instanceVar).toEqual('')
+    describe('buildInstanceVaribles', () => {
+        it('with unset variables, returns empty string', () => {
+            delete process.env.BUILD_PIPELINE_INSTANCE_VARS;
+            const instanceVar = out.buildInstanceVariables();
+            expect(instanceVar).toEqual('')
+        });
+    
+        it('with empty variables, returns empty string', () => {
+            process.env.BUILD_PIPELINE_INSTANCE_VARS = "{}";
+            const instanceVar = out.buildInstanceVariables();
+            expect(instanceVar).toEqual('')
+        });
+    
+        it('with bad json, it throws an exception', () => {
+            process.env.BUILD_PIPELINE_INSTANCE_VARS = "{695988";
+            expect(() => out.buildInstanceVariables()).toThrow();
+        });
+    
+        it('with valid instance variables, it builds variable string to append to url', () => {
+            process.env.BUILD_PIPELINE_INSTANCE_VARS = '{"name":"John", "age":30, "car":"Toyota"}';
+            const instanceVar = out.buildInstanceVariables();
+            expect(instanceVar).toEqual(`&vars.name="John"&vars.age="30"&vars.car="Toyota"`)
+        });
     });
 
-    it('with empty variables, returns empty string', () => {
-        process.env.BUILD_PIPELINE_INSTANCE_VARS = "{}";
-        const instanceVar = out.buildInstanceVariables();
-        expect(instanceVar).toEqual('')
-    });
-
-    it('with bad json, it throws an exception', () => {
-        process.env.BUILD_PIPELINE_INSTANCE_VARS = "{695988";
-        expect(() => out.buildInstanceVariables()).toThrow();
-    });
-
-    it('with valid instance variables, it builds variable string to append to url', () => {
-        process.env.BUILD_PIPELINE_INSTANCE_VARS = '{"name":"John", "age":30, "car":"Toyota"}';
-        const instanceVar = out.buildInstanceVariables();
-        expect(instanceVar).toEqual(`&vars.name="John"&vars.age="30"&vars.car="Toyota"`)
+    describe('buildUrl', () => {
+        it('defaults to using the current pipeline name', () => {
+            process.env.ATC_EXTERNAL_URL = 'https://example.com';
+            process.env.BUILD_PIPELINE_NAME = 'pipeline';
+            process.env.BUILD_TEAM_NAME = 'team';
+            const params = {
+                resource_name: 'resource',
+                webhook_token: 'token'
+            }
+            const instanceVar = out.buildUrl(null, params);
+            expect(instanceVar).toEqual("https://example.com/api/v1/teams/team/pipelines/pipeline/resources/resource/check/webhook?webhook_token=token")
+        });
+      
+        it('prefers the pipeline name from params', () => {
+            process.env.ATC_EXTERNAL_URL = 'https://example.com';
+            process.env.BUILD_PIPELINE_NAME = 'pipeline';
+            process.env.BUILD_TEAM_NAME = 'team';
+            const params = {
+                pipeline: 'another-pipeline',
+                resource_name: 'resource',
+                webhook_token: 'token'
+            }
+            const instanceVar = out.buildUrl(null, params);
+            expect(instanceVar).toEqual("https://example.com/api/v1/teams/team/pipelines/another-pipeline/resources/resource/check/webhook?webhook_token=token")
+        });
     });
 });

--- a/bin/validate.js
+++ b/bin/validate.js
@@ -46,7 +46,11 @@ const configSchema = {
                     transform: ['trim', 'toEnumCase'],
                     enum: validOperations,
                     errorMessage: { enum: 'must be either create or delete' }
-                }
+                },
+                pipeline:      { 
+                    type: 'string',
+                    transform: ['trim', 'toLowerCase']
+                },
             },
             required: ['org', 'repo', 'resource_name', 'webhook_token', 'operation']
         },

--- a/bin/validate.js
+++ b/bin/validate.js
@@ -51,6 +51,9 @@ const configSchema = {
                     type: 'string',
                     transform: ['trim', 'toLowerCase']
                 },
+                pipeline_instance_vars: { 
+                    type: 'object',
+                },
             },
             required: ['org', 'repo', 'resource_name', 'webhook_token', 'operation']
         },

--- a/bin/validate.test.js
+++ b/bin/validate.test.js
@@ -117,6 +117,7 @@ describe('validate.input', () => {
             'params.resource_name',
             'params.webhook_token',
             'params.operation',
+            'params.pipeline',
         ];
 
         constrainedFields.forEach(field => {
@@ -155,13 +156,15 @@ describe('validate.input', () => {
                 resource_name: '',
                 webhook_token: '',
                 operation: 'CrEaTe',
-                events: ['pUsH']
+                events: ['pUsH'],
+                pipeline: 'mYPipeline'
             }
         };
 
         expect(() => validate.config(config)).not.toThrow();
         expect(config.params.operation).toBe('create');
         expect(config.params.events).toEqual(['push']);
+        expect(config.params.pipeline).toBe('mypipeline');
     });
 
     it('trims whitespace', () => {
@@ -176,13 +179,15 @@ describe('validate.input', () => {
                 resource_name: '',
                 webhook_token: '',
                 operation: ' create ',
-                events: [' push ']
+                events: [' push '],
+                pipeline: ' mypipeline '
             }
         };
 
         expect(() => validate.config(config)).not.toThrow();
         expect(config.params.operation).toBe('create');
         expect(config.params.events).toEqual(['push']);
+        expect(config.params.pipeline).toBe('mypipeline');
     });
 
     it('checks fields with array constraint', () => {

--- a/bin/validate.test.js
+++ b/bin/validate.test.js
@@ -157,7 +157,8 @@ describe('validate.input', () => {
                 webhook_token: '',
                 operation: 'CrEaTe',
                 events: ['pUsH'],
-                pipeline: 'mYPipeline'
+                pipeline: 'mYPipeline',
+                pipeline_instance_vars: {}
             }
         };
 
@@ -180,7 +181,8 @@ describe('validate.input', () => {
                 webhook_token: '',
                 operation: ' create ',
                 events: [' push '],
-                pipeline: ' mypipeline '
+                pipeline: ' mypipeline ',
+                pipeline_instance_vars: {}
             }
         };
 
@@ -192,7 +194,7 @@ describe('validate.input', () => {
 
     it('checks fields with array constraint', () => {
         const constrainedFields = [
-            'params.events'
+            'params.events',
         ];
 
         constrainedFields.forEach(field => {
@@ -207,7 +209,41 @@ describe('validate.input', () => {
                     resource_name: '',
                     webhook_token: '',
                     operation: 'create',
-                    events: []
+                    events: [],
+                    pipeline: '',
+                    pipeline_instance_vars: {}
+                }
+            };
+
+            expect(() => validate.config(config)).not.toThrow();
+
+            const fieldTree = field.split('.');
+            config[fieldTree[0]][fieldTree[1]] = null;
+
+            expect(() => validate.config(config)).toThrow();
+        });
+    });
+
+    it('checks fields with object constraint', () => {
+        const constrainedFields = [
+            'params.pipeline_instance_vars'
+        ];
+
+        constrainedFields.forEach(field => {
+            const config = {
+                source: {
+                    github_api: '',
+                    github_token: ''
+                },
+                params: {
+                    org: '',
+                    repo: '',
+                    resource_name: '',
+                    webhook_token: '',
+                    operation: 'create',
+                    events: [],
+                    pipeline: '',
+                    pipeline_instance_vars: {}
                 }
             };
 


### PR DESCRIPTION
**What is the purpose of this pull request?**

- [ ] Bug fix
- [ ] Documentation update
- [ ] Code cleanup
- [x] New feature
- [ ] Other (please explain):

**Addresses #36**


**What changes did you make? (Give a brief overview)**
Add the capability to specify pipeline name and pipeline instance vars. This allows one pipeline to configure the webhooks for another one, which is useful when using [multi-branch workflows](https://concourse-ci.org/multi-branch-workflows.html), in which one pipeline is responsible for creating and destroying other pipelines.

Without this change there is no easy way for the parent pipeline to set the webhook in Github to trigger the child pipelines, nor to delete that webhook once the child pipeline is removed.


**Is there anything specific you would like reviewers to focus on?**
No