### PR TITLE
Match existing hook without payload secret

### DIFF
--- a/bin/out.js
+++ b/bin/out.js
@@ -88,7 +88,7 @@ async function processWebhook(source, params) {
     const config = {
         'url': url,
         'content_type': params.payload_content_type ? params.payload_content_type : 'json',
-        'secret': params.payload_secret
+        ...(params.payload_secret && {'secret': params.payload_secret}),
     };
 
     const body = {


### PR DESCRIPTION
<!--
    Make sure your pull request is ready:
    - Read the contributing guidelines: https://github.com/homedepot/github-webhook-resource/blob/master/CONTRIBUTING.md
    - Include tests for this change
    - Update documentation to reflect this change (if appropriate)
-->

**What is the purpose of this pull request?**
<!-- Remove the empty space and paste an "X" inside the [] next to the correct item. -->
- [ ] Bug fix
- [ ] Documentation update
- [ ] Code cleanup
- [ ] New feature
- [x] Other (please explain): React to a potential change in github api response.


**What changes did you make? (Give a brief overview)**
Change the desired hook config used to match against existing hooks to not include the secret property if its value is undefined. 

Without this change, the _.isMatch function is not able to find a match in the existing pipelines, and attempts to create the webhook again, resulting in an api error.

The error returned by the resource before this changes looked like the following:
```
Error while calling Github: StatusCodeError
Response Status: 422
Message: {
  "message": "Validation Failed",
  "errors": [
    {
      "resource": "Hook",
      "code": "custom",
      "message": "Hook already exists on this repository"
    },
    {
      "resource": "Hook",
      "code": "custom",
      "message": "Invalid config attribute: content-type"
    }
  ],
  "documentation_url": "https://docs.github.com/rest/repos/webhooks#create-a-repository-webhook",
  "status": "422"
}
```

**Is there anything specific you would like reviewers to focus on?**
No